### PR TITLE
feat(templates): ExampleTemplate-01 (Blinky) and Wizard binding (Issue #31)

### DIFF
--- a/CoreSim/src/RobotTwin.CoreSim/Catalogs/TemplateCatalog.cs
+++ b/CoreSim/src/RobotTwin.CoreSim/Catalogs/TemplateCatalog.cs
@@ -24,6 +24,44 @@ namespace RobotTwin.CoreSim.Catalogs
         {
             return new List<TemplateSpec>
             {
+                // Verification Template (Feature #31)
+                new TemplateSpec 
+                { 
+                    ID = "mvp.exampletemplate-01", 
+                    Name = "ExampleTemplate-01: Blinky", 
+                    Description = "Hello World: Arduino Uno + Resistor + LED on D13.",
+                    SystemType = "CircuitOnly",
+                    DefaultCircuit = new CircuitSpec 
+                    { 
+                        Name = "Blinky Circuit",
+                        Components = new List<ComponentInstance>
+                        {
+                            new ComponentInstance { X=0, Y=0, CatalogID="source_5v", InstanceID="pwr" },
+                            new ComponentInstance { X=0, Y=2, CatalogID="gnd",       InstanceID="gnd" },
+                            new ComponentInstance { X=4, Y=0, CatalogID="uno",       InstanceID="uno" },
+                            new ComponentInstance { X=8, Y=0, CatalogID="resistor",  InstanceID="r1" },
+                            new ComponentInstance { X=10, Y=0,CatalogID="led",       InstanceID="led1" }
+                        },
+                        Connections = new List<Connection>
+                        {
+                            new Connection { FromComponentID="pwr", FromPin="VCC", ToComponentID="uno", ToPin="5V" },
+                            new Connection { FromComponentID="pwr", FromPin="GND", ToComponentID="gnd", ToPin="GND" },
+                            new Connection { FromComponentID="uno", FromPin="GND", ToComponentID="gnd", ToPin="GND" },
+                            new Connection { FromComponentID="uno", FromPin="D13", ToComponentID="r1",  ToPin="1" },
+                            new Connection { FromComponentID="r1",  FromPin="2",   ToComponentID="led1",ToPin="A" },
+                            new Connection { FromComponentID="led1",FromPin="K",   ToComponentID="gnd", ToPin="GND" }
+                        }
+                    }
+                },
+                // Blank Template
+                new TemplateSpec
+                {
+                    ID = "mvp.blank",
+                    Name = "Blank Template",
+                    Description = "Start from an empty circuit-only project.",
+                    SystemType = "CircuitOnly",
+                    DefaultCircuit = new CircuitSpec { Name = "New Circuit" }
+                },
                 new TemplateSpec 
                 { 
                     ID = "mvp.linefollower", 

--- a/CoreSim/tests/RobotTwin.CoreSim.Tests/TemplateTests.cs
+++ b/CoreSim/tests/RobotTwin.CoreSim.Tests/TemplateTests.cs
@@ -3,6 +3,7 @@ using RobotTwin.CoreSim.Specs;
 using RobotTwin.CoreSim.Catalogs;
 using System.Text.Json;
 using System.Collections.Generic;
+using RobotTwin.CoreSim.Validation;
 
 namespace RobotTwin.CoreSim.Tests
 {
@@ -45,6 +46,31 @@ namespace RobotTwin.CoreSim.Tests
             var found = catalog.Find("t1");
             Assert.NotNull(found);
             Assert.Equal("Test Template", found.Name);
+        }
+
+        [Fact]
+        public void ExampleTemplate01_Blinky_ShouldBeValidAndRunnable()
+        {
+            var defaults = TemplateCatalog.GetDefaults();
+            var blinky = defaults.Find(t => t.ID == "mvp.exampletemplate-01");
+            
+            Assert.NotNull(blinky);
+            Assert.Equal("ExampleTemplate-01: Blinky", blinky.Name);
+            Assert.NotNull(blinky.DefaultCircuit);
+            
+            // Validate the circuit composition
+            var result = CircuitValidator.Validate(blinky.DefaultCircuit);
+            
+            // Should be valid with 0 errors
+            Assert.True(result.IsValid, $"Blinky template invalid: {string.Join(", ", result.Errors)}");
+            Assert.Empty(result.Errors);
+            
+            // Check essential components exist
+            Assert.Contains(blinky.DefaultCircuit.Components, c => c.InstanceID == "uno");
+            Assert.Contains(blinky.DefaultCircuit.Components, c => c.InstanceID == "led1");
+            
+            // Check wiring
+            Assert.Contains(blinky.DefaultCircuit.Connections, c => c.FromComponentID == "uno" && c.FromPin == "D13");
         }
     }
 }

--- a/UnityApp/Assets/Scripts/UI/ProjectWizardController.cs
+++ b/UnityApp/Assets/Scripts/UI/ProjectWizardController.cs
@@ -37,13 +37,41 @@ namespace RobotTwin.UI
         {
             _templates = TemplateCatalog.GetDefaults();
             
-            // For MVP: Simple list populate (or just debug log if UI isn't built yet)
+            // Populate ListView
+            if (_imgList != null)
+            {
+                _imgList.makeItem = () => new Label();
+                _imgList.bindItem = (element, index) => 
+                {
+                    (element as Label).text = _templates[index].Name;
+                };
+                
+                _imgList.itemsSource = _templates;
+                _imgList.selectionChanged += OnSelectionChanged;
+
+                // Refresh
+                _imgList.Rebuild();
+            }
+            
             Debug.Log($"Loaded {_templates.Count} templates.");
             
-            // Auto-select first
+            // Auto-select first if available
             if (_templates.Count > 0)
             {
-                SelectTemplate(_templates[0]);
+                if (_imgList != null) _imgList.SetSelection(0);
+                else SelectTemplate(_templates[0]);
+            }
+        }
+
+        private void OnSelectionChanged(IEnumerable<object> selection)
+        {
+            foreach(var item in selection)
+            {
+                if (item is TemplateSpec t)
+                {
+                    SelectTemplate(t);
+                    return; // Single select
+                }
             }
         }
 

--- a/docs/USER_QUICKSTART.md
+++ b/docs/USER_QUICKSTART.md
@@ -1,10 +1,22 @@
 # User Quickstart
-
+ 
 > [!NOTE]
 > This guide is under construction for MVP-0.
 
-## Getting Started
+## Verifying Installation with ExampleTemplate-01: Blinky
+
 1. Run `RoboTwinStudio.exe`.
 2. Click **New Project**.
-3. Select a **Template** (ExampleTemplate-01) or **Blank Template**.
-4. Click **Run**.
+3. Select **ExampleTemplate-01: Blinky**.
+   - Description should read: "Hello World: Arduino Uno + Resistor + LED on D13."
+4. Click **Create**.
+5. You should see the Circuit Studio with an Arduino Uno, Resistor, and LED pre-wired.
+6. Click **Validate** (top right) -> Confirm "Valid".
+7. Click **Run** (top right) -> Run Mode should launch (black screen with telemetry logs).
+8. Verify logs are generated in `%AppData%/RoboTwinStudio/Runs`.
+
+## Creating a New Project
+
+1. Run `RoboTwinStudio.exe` or click Back.
+2. Select **Blank Template**.
+3. Click **Create** to start with an empty canvas.


### PR DESCRIPTION
Fixes #31

## Model Tier
- [x] PRO
- **Why?**: Logic required ensuring valid component IDs and wiring in CoreSim, plus Unity UI binding.

## Changes
- **CoreSim**: Added 'ExampleTemplate-01: Blinky' and 'Blank Template' to Catalog.
- **CoreSim**: Added unit test 'ExampleTemplate01_Blinky_ShouldBeValidAndRunnable'.
- **UnityApp**: Updated ProjectWizardController to populate the template list from catalog.
- **Docs**: Updated Quickstart with verification steps.

## Verification
- **Automated**: CoreSim tests passed (CircuitValidator confirmed valid wiring).
- **Manual Smoke**: Verified via code review that Wizard binds 'Name' and selection logic passes 'TemplateSpec' to SessionManager.

## Summary by Sourcery

Add a new example "Blinky" template and blank template, wire them into the project wizard UI, and document how to use them as an installation verification step.

New Features:
- Introduce ExampleTemplate-01: Blinky circuit template with predefined components and wiring.
- Add a Blank Template option for starting empty circuit-only projects.
- Populate the project creation wizard template list from the template catalog with selection binding to the active template.

Documentation:
- Update the user quickstart to guide verifying installation using the Blinky template and to describe creating a project from the blank template.

Tests:
- Add a validation test ensuring the Blinky template is present, circuit-valid, and correctly wired.