### PR TITLE
fix(ci): use pwsh shell for context pack script verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,10 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Verify context pack script
+      shell: pwsh
       run: |
-        powershell -ExecutionPolicy Bypass -File ./tools/export_context_pack.ps1 -Mode MIN -OutDir $env:RUNNER_TEMP/context_pack -SkipGh
-      shell: bash
+        $outDir = Join-Path $env:RUNNER_TEMP "context_pack"
+        pwsh -NoProfile -ExecutionPolicy Bypass -File ./tools/export_context_pack.ps1 -Mode MIN -OutDir $outDir -SkipGh
 
     - name: Verify docs/repo_files.txt freshness
       run: |


### PR DESCRIPTION
Fixes #56

**Changes**:
- Switches CI step shell to pwsh.
- Uses Join-Path to construct $OutDir reliably.

**Model used**: LIGHT (CI fix)

## Summary by Sourcery

Update CI workflow to run the context pack verification script using PowerShell Core with a reliably constructed temporary output directory.

CI:
- Change the context pack verification step to use the pwsh shell directly in the CI workflow.
- Build the context pack output directory path using Join-Path against the runner temp directory for more robust path handling.