### PR TITLE
fix(unity): resolve CircuitStudioController style errors & missing test-framework

### DIFF
--- a/UnityApp/Assets/Scripts/UI/CircuitStudio/CircuitStudioController.cs
+++ b/UnityApp/Assets/Scripts/UI/CircuitStudio/CircuitStudioController.cs
@@ -108,8 +108,14 @@ namespace RobotTwin.UI
                 foreach (var c in _currentCircuit.Components)
                 {
                     var lbl = new Label($"{c.InstanceID} ({c.CatalogID})");
-                    lbl.style.borderWidth = 1;
-                    lbl.style.borderColor = Color.gray;
+                    lbl.style.borderLeftWidth = 1;
+                    lbl.style.borderRightWidth = 1;
+                    lbl.style.borderTopWidth = 1;
+                    lbl.style.borderBottomWidth = 1;
+                    lbl.style.borderLeftColor = Color.gray;
+                    lbl.style.borderRightColor = Color.gray;
+                    lbl.style.borderTopColor = Color.gray;
+                    lbl.style.borderBottomColor = Color.gray;
                     lbl.style.paddingTop = 5;
                     lbl.style.paddingBottom = 5;
                     lbl.style.marginBottom = 2;

--- a/UnityApp/Packages/manifest.json
+++ b/UnityApp/Packages/manifest.json
@@ -18,6 +18,7 @@
     "com.unity.modules.terrain": "1.0.0",
     "com.unity.modules.terrainphysics": "1.0.0",
     "com.unity.modules.tilemap": "1.0.0",
+    "com.unity.test-framework": "1.3.9",
     "com.unity.modules.ui": "1.0.0",
     "com.unity.modules.uielements": "1.0.0",
     "com.unity.modules.umbra": "1.0.0",

--- a/docs/repo_files.txt
+++ b/docs/repo_files.txt
@@ -1,5 +1,5 @@
-﻿# GeneratedUtc: 2025-12-24T08:02:58Z
-# Commit: 847857c
+﻿# GeneratedUtc: 2025-12-24T08:19:15Z
+# Commit: 14c743e
 # FileCount: 125
 
 .agent/workflows/main_force_sync_workflow.md


### PR DESCRIPTION
## Summary
Fixed compilation errors in CircuitStudioController.cs by replacing IStyle shorthand properties.
Added com.unity.test-framework to manifest to fix CoreSimIntegrationTests.

## Model
LIGHT

## Verification
- Unity Smoke: Pass
- CoreSim Tests: Pass

## Summary by Sourcery

Fix styling configuration in CircuitStudioController and ensure Unity test framework is available in the project manifest.

Bug Fixes:
- Correct UI label border styling in CircuitStudioController to avoid compilation or runtime style errors.
- Add the Unity test framework package to the manifest so CoreSim integration tests can run successfully.

Documentation:
- Update repository documentation index to reflect current files if needed.