### PR TITLE
feat: harden shared info pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,30 @@ jobs:
     steps:
     - uses: actions/checkout@v6
 
+    - name: Verify Context Pack (Shell Check)
+      shell: pwsh
+      run: |
+        $OutDir = Join-Path $env:GITHUB_WORKSPACE "docs/antigravity/context_exports"
+        Write-Host "Context export directory: $OutDir"
+        # Just verification that path construction works in pwsh
+
+    - name: Guardrail - Check Ignored Files
+      shell: pwsh
+      run: |
+        # Fail if .gpt is tracked
+        $gpt = git ls-files .gpt
+        if ($gpt) {
+            Write-Error "CRITICAL: .gpt folder is tracked! It must be gitignored. Found: $gpt"
+            exit 1
+        }
+        # Fail if workspace_snapshot is tracked
+        $snap = git ls-files workspace_snapshot.txt
+        if ($snap) {
+            Write-Error "CRITICAL: workspace_snapshot.txt is tracked!"
+            exit 1
+        }
+        Write-Host "Guardrail passed: No forbidden files tracked."
+
     - name: Verify context pack script
       shell: pwsh
       run: |

--- a/docs/antigravity/SHARED_INFO_PIPELINE.md
+++ b/docs/antigravity/SHARED_INFO_PIPELINE.md
@@ -1,0 +1,35 @@
+# Shared Info Pipeline
+
+## Overview
+RoboTwin Studio enforces a "Shared Info" workflow to persist session context off-repo. This ensures that even between sessions or across different LLM instances, the full context (logs, repo map, recent activity) is available without polluting the Git history with artifacts.
+
+**Frequency**: Runs automatically at the end of every agent session.
+**Artifact**: `session_YYYYMMDD_HHMMSSZ.zip`
+**Location**: `gdrive:robotwin_studio/shared_infos/`
+
+## Zip Content
+The zip file contains the `docs/` folder from the workspace, which includes:
+- `docs/antigravity/LAST_RUN.md` (End of session status)
+- `docs/antigravity/ACTIVITY_LOG.md` (Cumulative history)
+- `docs/antigravity/context_exports/latest/` (Full context pack: git log, file list, gh issues, etc.)
+- Architecture & Setup docs.
+
+## Prerequisite: Rclone
+To participate in this pipeline (upload or download), the machine must have `rclone` installed and configured.
+- **Remote Name**: `gdrive` (configurable via script args)
+- **Path**: `robotwin_studio/shared_infos/`
+
+*No secrets are stored in this repository.*
+
+## Retrieving Context
+To pull the latest session context into your local environment:
+
+```powershell
+./tools/get_latest_shared_info.ps1
+```
+
+This will:
+1. List files in the shared drive folder.
+2. Identify the most recent `session_*.zip`.
+3. Download it to `.gpt/shared_info/latest/`.
+4. Extract contents to `.gpt/shared_info/latest/docs/`.

--- a/docs/repo_files.txt
+++ b/docs/repo_files.txt
@@ -1,6 +1,6 @@
-﻿# GeneratedUtc: 2025-12-24T15:36:01Z
-# Commit: 4028250
-# FileCount: 125
+﻿# GeneratedUtc: 2025-12-24T16:12:14Z
+# Commit: e16bf13
+# FileCount: 126
 
 .agent/workflows/main_force_sync_workflow.md
 .github/dependabot.yml
@@ -59,6 +59,7 @@ docs/USER_QUICKSTART.md
 docs/VERSIONS.md
 global.json
 README.md
+tools/end_session_shared_info.ps1
 tools/export_context_pack.ps1
 tools/export_context_pack_min.ps1
 tools/run_unity_smoke.ps1

--- a/tools/get_latest_shared_info.ps1
+++ b/tools/get_latest_shared_info.ps1
@@ -1,0 +1,51 @@
+param (
+    [string]$DriveRemote = "gdrive:",
+    [string]$DriveFolder = "robotwin_studio/shared_infos"
+)
+
+$ErrorActionPreference = "Stop"
+$RepoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
+$DestDir = Join-Path $RepoRoot ".gpt/shared_info/latest"
+
+# 1. Check Rclone
+if (-not (Get-Command rclone -ErrorAction SilentlyContinue)) {
+    Write-Error "rclone not found in PATH."
+    exit 1
+}
+
+# 2. Find Latest Zip
+$RemotePath = "$DriveRemote$DriveFolder"
+Write-Host ">>> Listing files in $RemotePath..." -ForegroundColor Cyan
+
+# Parse lsjson output to find latest by mod time or name (name has timestamp)
+try {
+    $Json = rclone lsjson $RemotePath | ConvertFrom-Json
+    $Latest = $Json | Where-Object { $_.Name -match "^session_\d{8}_\d{6}Z\.zip$" } | Sort-Object Name -Descending | Select-Object -First 1
+}
+catch {
+    Write-Error "Failed to list files: $_"
+    exit 1
+}
+
+if (-not $Latest) {
+    Write-Warning "No 'session_*.zip' files found in $RemotePath."
+    exit 0
+}
+
+Write-Host ">>> Found latest: $($Latest.Name)" -ForegroundColor Green
+
+# 3. Prepare Dest
+if (Test-Path $DestDir) { Remove-Item $DestDir -Recurse -Force | Out-Null }
+New-Item -ItemType Directory -Path $DestDir -Force | Out-Null
+
+# 4. Download
+$LocalZip = Join-Path $DestDir $Latest.Name
+Write-Host ">>> Downloading to $LocalZip..." -ForegroundColor Cyan
+rclone copyto "$RemotePath/$($Latest.Name)" $LocalZip
+
+# 5. Extract
+Write-Host ">>> Extracting..." -ForegroundColor Cyan
+Expand-Archive -Path $LocalZip -DestinationPath $DestDir -Force
+
+Write-Host ">>> Done! Context extracted to $DestDir" -ForegroundColor Green
+Write-Host "See extracted docs in: $(Join-Path $DestDir 'docs')" -ForegroundColor Gray


### PR DESCRIPTION
## Summary
Operationalized 'Shared Info' workflow.

## Changes
- Added 'docs/antigravity/SHARED_INFO_PIPELINE.md'.
- Added 'tools/get_latest_shared_info.ps1' for context retrieval.
- Added CI guardrail to ban '.gpt/' tracking.

## Model
PRO

## Verification
- 'end_session_shared_info.ps1' Verified.
- 'get_latest_shared_info.ps1' Verified (Download success).
- CI Guardrail added.

## Summary by Sourcery

Harden the shared session context pipeline by documenting the workflow, adding a retrieval script, and enforcing CI guardrails against tracking transient context artifacts.

New Features:
- Add a PowerShell script to download and extract the latest shared session context bundle from remote storage into the local workspace.

Enhancements:
- Document the Shared Info pipeline, its artifacts, prerequisites, and retrieval steps for RoboTwin Studio participants.

CI:
- Extend the CI workflow with guardrails to fail builds if transient context artifacts such as the .gpt folder or workspace_snapshot.txt become tracked files.