### PR TITLE
feat: Unity CI Action (#32)

### DIFF
--- a/.github/workflows/unity_ci.yml
+++ b/.github/workflows/unity_ci.yml
@@ -1,0 +1,91 @@
+name: Unity CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+jobs:
+  probe:
+    name: Probe Unity Environment
+    runs-on: windows-latest
+    outputs:
+      run_unity: ${{ steps.check_secret.outputs.run_unity }}
+      unity_version: ${{ steps.get_version.outputs.unity_version }}
+    
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Check for Unity License
+        id: check_secret
+        shell: pwsh
+        run: |
+          if ("${{ secrets.UNITY_LICENSE }}" -ne "") {
+            Write-Host "UNITY_LICENSE secret found. Unity tests will run."
+            "run_unity=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          } else {
+            Write-Warning "UNITY_LICENSE secret missing. Unity tests will be SKIPPED."
+            "run_unity=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          }
+
+      - name: Get Unity Version
+        id: get_version
+        shell: pwsh
+        run: |
+          $verFile = "UnityApp/ProjectSettings/ProjectVersion.txt"
+          if (Test-Path $verFile) {
+            $content = Get-Content $verFile
+            # Parse 'm_EditorVersion: 2022.3.62f3'
+            $versionLine = $content | Select-String "m_EditorVersion:\s*(.*)"
+            if ($versionLine) {
+                $version = $versionLine.Matches.Groups[1].Value.Trim()
+                Write-Host "Detected Unity Version: $version"
+                "unity_version=$version" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+            } else {
+                Write-Error "Could not parse m_EditorVersion from $verFile"
+                exit 1
+            }
+          } else {
+            Write-Error "$verFile not found!"
+            exit 1
+          }
+
+  unity-tests:
+    name: Unity EditMode Tests
+    needs: probe
+    if: needs.probe.outputs.run_unity == 'true'
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Cache Library
+        uses: actions/cache@v3
+        with:
+          path: UnityApp/Library
+          key: Library-${{ runner.os }}-${{ needs.probe.outputs.unity_version }}-${{ hashFiles('UnityApp/Packages/manifest.json', 'UnityApp/Packages/packages-lock.json') }}
+          restore-keys: |
+            Library-${{ runner.os }}-${{ needs.probe.outputs.unity_version }}-
+            Library-${{ runner.os }}-
+      
+      - name: Run EditMode Tests
+        uses: game-ci/unity-test-runner@v4
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+        with:
+          projectPath: UnityApp
+          unityVersion: ${{ needs.probe.outputs.unity_version }}
+          testMode: editmode
+          artifactsPath: artifacts
+          
+      - name: Upload Test Results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: Test Results
+          path: artifacts

--- a/docs/antigravity/MVP_SCOPE.md
+++ b/docs/antigravity/MVP_SCOPE.md
@@ -165,10 +165,19 @@ Example contents (illustrative):
 ## 7) Realistic Failures (MVP Subset)
 
 MVP must demonstrate at least one deterministic failure scenario, visible live and in report:
-
 - Power: battery sag / brownout reset
 - Actuation: torque saturation
 - Thermal: thermal derating (simple)
+
+### CI/CD
+- **Platform**: GitHub Actions (Windows Runners).
+- **Core Checks**: `dotnet test` (CoreSim), Governance checks (Repo Index, Ignore Rules).
+- **Unity Validation**:
+  - Workflow: `.github/workflows/unity_ci.yml`
+  - Scope: EditMode logic tests, Compilation.
+  - **Conditional**: Runs ONLY if `UNITY_LICENSE` secret is present. Skips gracefully on forks/PRs without secrets.
+  - Version: Auto-detected from `ProjectVersion.txt` (`2022.3.62f3`).
+- **Artifacts**: Shared Info Zip (Drive), Test Results (GitHub Artifacts).
 
 ## 8) Exclusions for MVP (Initial)
 


### PR DESCRIPTION
## Summary
Implemented conditional Unity CI workflow for Windows.

## Changes
- Added '.github/workflows/unity_ci.yml'.
  - Probes for UNITY_LICENSE secret.
  - Probes for Unity Version from ProjectVersion.txt.
  - Runs EditMode tests if licensed.
  - Skips gracefully if no license (forks/PRs).
- Updated 'docs/antigravity/MVP_SCOPE.md'.

## Model
PRO

## Verification
- Repo/CoreSim checks passed.
- Workflow syntax verified.

## Summary by Sourcery

Add a conditional Unity CI workflow on Windows and document its role in the MVP scope.

CI:
- Introduce a Unity CI GitHub Actions workflow that probes for a Unity license and project version, then runs cached EditMode tests on Windows when licensed.

Documentation:
- Document the CI/CD expectations for the MVP, including Unity validation workflow behavior, conditions, and artifacts.